### PR TITLE
Use pedersen hash instead of sha256 for merkle tree to decrease circuit size

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ ecdsa
 fastecdsa
 sympy
 cairo-lang
+zokrates-pycrypto

--- a/zokrates_snark/compile_programm.sh
+++ b/zokrates_snark/compile_programm.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-zokrates compile -i merkle_proof.zok
+zokrates compile -i merkle_proof_pedersen.zok
 # perform the setup phase
 zokrates setup
 

--- a/zokrates_snark/merkle_proof_pedersen.zok
+++ b/zokrates_snark/merkle_proof_pedersen.zok
@@ -1,0 +1,32 @@
+import "hashes/pedersen/512bit" as hash;
+import "hashes/sha256/512bitPadded" as sha256;
+import "hashes/utils/256bitsDirectionHelper" as multiplex;
+
+const u32 DEPTH = 7;
+
+// Merke-Tree inclusion proof for tree depth 3 using SNARK-efficient pedersen hashes
+// directionSelector => true if current digest is on the rhs of the hashes
+
+def main(\
+  bool vote,\
+  u32[4] serial_number,\
+  private u32[4] secret,\
+  u32[8] root,\
+  private bool[DEPTH] directionSelector,\
+  private u32[DEPTH][8] path\
+) {
+  u32[8] leaf = sha256([...serial_number, ...secret], [0, 0, 0, 0, 0, 0, 0, if vote { 1 } else { 0 }]);
+
+  // Start from the leaf
+  u32[8] mut digest = leaf;
+
+  // Loop up the tree
+  for u32 i in 0..DEPTH {
+    // Concatenate two u32[8] arrays in an order defined by a boolean selector
+    u32[16] preimage = multiplex(directionSelector[i], digest, path[i]);
+    digest = hash(preimage);
+  }
+
+  assert(digest == root);
+  return;
+}


### PR DESCRIPTION
The commitments (leaf nodes of the merkle tree) are still hashed using sha256, because pedersen is not pseudorandom.
Also, increase merkle tree depth to 7.

The size of the circuit went down from ~400 MB to ~100 MB. If we would get rid of sha256 altogether (using only pedersen), the circuit size would decrease to ~4 MB.